### PR TITLE
feat(kmp-actual-stubs): backwards compatible Kotlin 2.3+ support

### DIFF
--- a/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/Ids.kt
+++ b/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/Ids.kt
@@ -3,6 +3,8 @@ package net.msrandom.stub
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 
+const val PLUGIN_ID = "net.msrandom.stub"
+
 val STUB: ClassId = ClassId.topLevel(FqName("net.msrandom.stub.Stub"))
 
 val UNSUPPORTED_OPERATION_EXCEPTION = ClassId.topLevel(FqName("java.lang.UnsupportedOperationException"))

--- a/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/Ids.kt
+++ b/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/Ids.kt
@@ -3,7 +3,7 @@ package net.msrandom.stub
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 
-const val PLUGIN_ID = "net.msrandom.stub"
+public const val PLUGIN_ID = "net.msrandom.stub"
 
 val STUB: ClassId = ClassId.topLevel(FqName("net.msrandom.stub.Stub"))
 

--- a/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/StubCompilerPlugin.kt
+++ b/kmp-actual-stubs/compiler-plugin/src/main/kotlin/net/msrandom/stub/StubCompilerPlugin.kt
@@ -17,6 +17,8 @@ class StubCompilerPlugin : CompilerPluginRegistrar() {
 
     override val supportsK2: Boolean = true
 
+    val pluginId: String = PLUGIN_ID
+
     override fun ExtensionStorage.registerExtensions(
         configuration: CompilerConfiguration
     ) {


### PR DESCRIPTION
Following the discussion [here](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1046/changes), added `pluginId` field to a plugin class.

This will allow to support newer kotlin version without breaking backwards compat